### PR TITLE
Add use of template to Install command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /faasd
 hosts
 /resolv.conf
+.idea/

--- a/pkg/systemd/systemd.go
+++ b/pkg/systemd/systemd.go
@@ -66,7 +66,7 @@ func DaemonReload() error {
 
 func InstallUnit(name string) error {
 	tmplName := "./hack/" + name + ".service"
-	tmpl, err := template.ParseFiles()
+	tmpl, err := template.ParseFiles(tmplName)
 
 	if err != nil {
 		return fmt.Errorf("error loading template %s, error %s", tmplName, err)


### PR DESCRIPTION
The tamplate name wasnt used, so
the command gave an error saying that
no template was used.

Signed-off-by: Alistair Hey <alistair@heyal.co.uk>

Tested:
BEFORE:
```sh
root@raspberrypi:~/go/src/github.com/alexellis/faasd# sudo faasd install
Error: error loading template ./hack/faas-containerd.service, error template: no files named in call to ParseFiles

```

AFTER:
```sh
root@raspberrypi:~/go/src/github.com/alexellis/faasd# sudo ./faasd install
root@raspberrypi:~/go/src/github.com/alexellis/faasd# 

```