### PR TITLE
Copy headers in both directions in proxy

### DIFF
--- a/pkg/supervisor.go
+++ b/pkg/supervisor.go
@@ -153,7 +153,7 @@ func (s *Supervisor) Start(svcs []Service) error {
 		)
 
 		if containerCreateErr != nil {
-			log.Println(containerCreateErr)
+			log.Printf("Error creating container %s\n", containerCreateErr)
 			return containerCreateErr
 		}
 
@@ -161,7 +161,7 @@ func (s *Supervisor) Start(svcs []Service) error {
 
 		task, err := newContainer.NewTask(ctx, cio.NewCreator(cio.WithStdio))
 		if err != nil {
-			log.Println(err)
+			log.Printf("Error creating task: %s\n", err)
 			return err
 		}
 
@@ -175,19 +175,21 @@ func (s *Supervisor) Start(svcs []Service) error {
 		writeErr := ioutil.WriteFile("hosts", hosts, 0644)
 
 		if writeErr != nil {
-			log.Println("Error writing hosts file")
+			log.Printf("Error writing file %s %s\n", "hosts", writeErr)
 		}
 		// os.Chown("hosts", 101, 101)
 
-		exitStatusC, err := task.Wait(ctx)
+		_, err = task.Wait(ctx)
 		if err != nil {
-			log.Println(err)
+			log.Printf("Wait err: %s\n", err)
 			return err
 		}
-		log.Println("Exited: ", exitStatusC)
 
-		if err := task.Start(ctx); err != nil {
-			log.Println("Task err: ", err)
+		log.Printf("Task: %s\tContainer: %s\n", task.ID(), newContainer.ID())
+		// log.Println("Exited: ", exitStatusC)
+
+		if err = task.Start(ctx); err != nil {
+			log.Printf("Task err: %s\n", err)
 			return err
 		}
 	}


### PR DESCRIPTION
* Issue was detected whilst testing 0.4.0 from @Waterdrips which
added basic auth, but the header was not being propagated.
* This code is tested in OpenFaaS already, but unit tests will
be added retrospectively.
* Proxy now reads the gateway URL via a channel instead of from
a file to make unit testing easier.

Could not test e2e on Linux due to error about the queue-worker
container existing. I checked and it didn't, the error code was
"unknown"

Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>