### PR TITLE
Switch data directory to /var/lib/faasd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ prepare-test:
 
 .PHONY: test-e2e
 test-e2e:
-	sudo cat /run/faasd/secrets/basic-auth-password | /usr/local/bin/faas-cli login --password-stdin
+	sudo cat /var/lib/faasd/secrets/basic-auth-password | /usr/local/bin/faas-cli login --password-stdin
 	/usr/local/bin/faas-cli store deploy figlet --env write_timeout=1s --env read_timeout=1s
 	sleep 2
 	/usr/local/bin/faas-cli list -v

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Done:
 * [x] Clear / remove containers and tasks with SIGTERM / SIGINT
 * [x] Determine armhf/arm64 containers to run for gateway
 * [x] Configure `basic_auth` to protect the OpenFaaS gateway and faasd-provider HTTP API
-* [x] Setup custom working directory for faasd `/run/faasd/`
+* [x] Setup custom working directory for faasd `/var/lib/faasd/`
 * [x] Use CNI to create network namespaces and adapters
 
 ## Tutorial: Get started on armhf / Raspberry Pi
@@ -134,7 +134,7 @@ sudo curl -fSLs "https://github.com/alexellis/faasd/releases/download/0.4.4/faas
 
 ### At run-time
 
-Look in `hosts` in the current working folder or in `/run/faasd/` to get the IP for the gateway or Prometheus
+Look in `hosts` in the current working folder or in `/var/lib/faasd/` to get the IP for the gateway or Prometheus
 
 ```sh
 127.0.0.1      localhost
@@ -158,8 +158,8 @@ Since faasd-provider uses containerd heavily it is not running as a container, b
 
 * basic-auth
 
-    You will then need to get the basic-auth password, it is written to `/run/faasd/secrets/basic-auth-password` if you followed the above instructions.
-The default Basic Auth username is `admin`, which is written to `/run/faasd/secrets/basic-auth-user`, if you wish to use a non-standard user then create this file and add your username (no newlines or other characters) 
+    You will then need to get the basic-auth password, it is written to `/var/lib/faasd/secrets/basic-auth-password` if you followed the above instructions.
+The default Basic Auth username is `admin`, which is written to `/var/lib/faasd/secrets/basic-auth-user`, if you wish to use a non-standard user then create this file and add your username (no newlines or other characters) 
 
 #### Installation with systemd
 

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -18,8 +18,8 @@ var installCmd = &cobra.Command{
 	RunE:  runInstall,
 }
 
-const faasdwd = "/run/faasd"
-const faasdProviderWd = "/run/faasd-provider"
+const faasdwd = "/var/lib/faasd"
+const faasdProviderWd = "/var/lib/faasd-provider"
 
 func runInstall(_ *cobra.Command, _ []string) error {
 
@@ -87,7 +87,7 @@ func runInstall(_ *cobra.Command, _ []string) error {
 	}
 
 	fmt.Println(`Login with:
-  sudo cat /run/faasd/secrets/basic-auth-password | faas-cli login -s`)
+  sudo cat /var/lib/faasd/secrets/basic-auth-password | faas-cli login -s`)
 
 	return nil
 }

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -53,7 +53,7 @@ var defaultCNIConf = fmt.Sprintf(`
 }
 `, pkg.DefaultNetworkName, pkg.DefaultBridgeName, pkg.DefaultSubnet)
 
-const secretMountDir = "/run/secrets"
+const containerSecretMountDir = "/run/secrets"
 
 func runUp(_ *cobra.Command, _ []string) error {
 
@@ -208,18 +208,18 @@ func makeServiceDefinitions(archSuffix string) []pkg.Service {
 			Image: "docker.io/openfaas/basic-auth-plugin:0.18.10" + archSuffix,
 			Env: []string{
 				"port=8080",
-				"secret_mount_path=" + secretMountDir,
+				"secret_mount_path=" + containerSecretMountDir,
 				"user_filename=basic-auth-user",
 				"pass_filename=basic-auth-password",
 			},
 			Mounts: []pkg.Mount{
 				pkg.Mount{
 					Src:  path.Join(path.Join(wd, "secrets"), "basic-auth-password"),
-					Dest: path.Join(secretMountDir, "basic-auth-password"),
+					Dest: path.Join(containerSecretMountDir, "basic-auth-password"),
 				},
 				pkg.Mount{
 					Src:  path.Join(path.Join(wd, "secrets"), "basic-auth-user"),
-					Dest: path.Join(secretMountDir, "basic-auth-user"),
+					Dest: path.Join(containerSecretMountDir, "basic-auth-user"),
 				},
 			},
 			Caps: []string{"CAP_NET_RAW"},
@@ -257,18 +257,18 @@ func makeServiceDefinitions(archSuffix string) []pkg.Service {
 				"faas_nats_port=4222",
 				"auth_proxy_url=http://basic-auth-plugin:8080/validate",
 				"auth_proxy_pass_body=false",
-				"secret_mount_path=" + secretMountDir,
+				"secret_mount_path=" + containerSecretMountDir,
 				"scale_from_zero=true",
 			},
 			Image: "docker.io/openfaas/gateway:0.18.8" + archSuffix,
 			Mounts: []pkg.Mount{
 				pkg.Mount{
 					Src:  path.Join(path.Join(wd, "secrets"), "basic-auth-password"),
-					Dest: path.Join(secretMountDir, "basic-auth-password"),
+					Dest: path.Join(containerSecretMountDir, "basic-auth-password"),
 				},
 				pkg.Mount{
 					Src:  path.Join(path.Join(wd, "secrets"), "basic-auth-user"),
-					Dest: path.Join(secretMountDir, "basic-auth-user"),
+					Dest: path.Join(containerSecretMountDir, "basic-auth-user"),
 				},
 			},
 			Caps: []string{"CAP_NET_RAW"},
@@ -284,17 +284,17 @@ func makeServiceDefinitions(archSuffix string) []pkg.Service {
 				"max_inflight=1",
 				"write_debug=false",
 				"basic_auth=true",
-				"secret_mount_path=" + secretMountDir,
+				"secret_mount_path=" + containerSecretMountDir,
 			},
 			Image: "docker.io/openfaas/queue-worker:0.9.0",
 			Mounts: []pkg.Mount{
 				pkg.Mount{
 					Src:  path.Join(path.Join(wd, "secrets"), "basic-auth-password"),
-					Dest: path.Join(secretMountDir, "basic-auth-password"),
+					Dest: path.Join(containerSecretMountDir, "basic-auth-password"),
 				},
 				pkg.Mount{
 					Src:  path.Join(path.Join(wd, "secrets"), "basic-auth-user"),
-					Dest: path.Join(secretMountDir, "basic-auth-user"),
+					Dest: path.Join(containerSecretMountDir, "basic-auth-user"),
 				},
 			},
 			Caps: []string{"CAP_NET_RAW"},


### PR DESCRIPTION
Fix: #26

Tested e2e on Ubuntu with `x86_64`

Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

## Checklist:

Commits:

- [x] My commit message has a body and describe how this was tested and why it is required.
- [x] I have signed-off my commits with `git commit -s` for the Developer Certificate of Origin (DCO)

Code:

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.

Docs:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
