### PR TITLE
Add secrets support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ hosts
 basic-auth-user
 basic-auth-password
 /bin
+/secrets

--- a/cmd/provider.go
+++ b/cmd/provider.go
@@ -66,17 +66,20 @@ func runProvider(_ *cobra.Command, _ []string) error {
 
 	invokeResolver := handlers.NewInvokeResolver(client)
 
+	userSecretPath := path.Join(wd, "secrets")
+
 	bootstrapHandlers := types.FaaSHandlers{
 		FunctionProxy:        proxy.NewHandlerFunc(*config, invokeResolver),
 		DeleteHandler:        handlers.MakeDeleteHandler(client, cni),
-		DeployHandler:        handlers.MakeDeployHandler(client, cni),
+		DeployHandler:        handlers.MakeDeployHandler(client, cni, userSecretPath),
 		FunctionReader:       handlers.MakeReadHandler(client),
 		ReplicaReader:        handlers.MakeReplicaReaderHandler(client),
 		ReplicaUpdater:       handlers.MakeReplicaUpdateHandler(client, cni),
-		UpdateHandler:        handlers.MakeUpdateHandler(client, cni),
+		UpdateHandler:        handlers.MakeUpdateHandler(client, cni, userSecretPath),
 		HealthHandler:        func(w http.ResponseWriter, r *http.Request) {},
 		InfoHandler:          handlers.MakeInfoHandler(Version, GitCommit),
 		ListNamespaceHandler: listNamespaces(),
+		SecretHandler:        handlers.MakeSecretHandler(client, userSecretPath),
 	}
 
 	log.Printf("Listening on TCP port: %d\n", *config.TCPPort)

--- a/pkg/provider/handlers/secret.go
+++ b/pkg/provider/handlers/secret.go
@@ -1,0 +1,111 @@
+package handlers
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"path"
+
+	"github.com/containerd/containerd"
+	"github.com/openfaas/faas-provider/types"
+)
+
+const secretFilePermission = 0644
+
+func MakeSecretHandler(c *containerd.Client, mountPath string) func(w http.ResponseWriter, r *http.Request) {
+
+	err := os.MkdirAll(mountPath, secretFilePermission)
+	if err != nil {
+		log.Printf("Creating path: %s, error: %s\n", mountPath, err)
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Body != nil {
+			defer r.Body.Close()
+		}
+
+		switch r.Method {
+		case http.MethodGet:
+			listSecrets(c, w, r, mountPath)
+		case http.MethodPost:
+			createSecret(c, w, r, mountPath)
+		case http.MethodPut:
+			createSecret(c, w, r, mountPath)
+		case http.MethodDelete:
+			deleteSecret(c, w, r, mountPath)
+		default:
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+	}
+}
+
+func listSecrets(c *containerd.Client, w http.ResponseWriter, r *http.Request, mountPath string) {
+	files, err := ioutil.ReadDir(mountPath)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	secrets := []types.Secret{}
+	for _, f := range files {
+		secrets = append(secrets, types.Secret{Name: f.Name()})
+	}
+
+	bytesOut, _ := json.Marshal(secrets)
+	w.Write(bytesOut)
+}
+
+func createSecret(c *containerd.Client, w http.ResponseWriter, r *http.Request, mountPath string) {
+	secret, err := parseSecret(r)
+	if err != nil {
+		log.Printf("[secret] error %s", err.Error())
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	err = ioutil.WriteFile(path.Join(mountPath, secret.Name), []byte(secret.Value), secretFilePermission)
+
+	if err != nil {
+		log.Printf("[secret] error %s", err.Error())
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}
+
+func parseSecret(r *http.Request) (types.Secret, error) {
+	secret := types.Secret{}
+	bytesOut, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return secret, err
+	}
+
+	err = json.Unmarshal(bytesOut, &secret)
+	return secret, err
+}
+
+func deleteSecret(c *containerd.Client, w http.ResponseWriter, r *http.Request, mountPath string) {
+	secret, err := parseSecret(r)
+	if err != nil {
+		log.Printf("[secret] error %s", err.Error())
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if err != nil {
+		log.Printf("[secret] error %s", err.Error())
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	err = os.Remove(path.Join(mountPath, secret.Name))
+
+	if err != nil {
+		log.Printf("[secret] error %s", err.Error())
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}


### PR DESCRIPTION
Adds secrets support and binding of secrets at runtime to
functions. Files are written in plain-text to a 0644 permission
folder which can only be read by root and the containers
requesting the secret through the OpenFaaS API.

Tested by deploying an alpine function using "cat" as its
fprocess.

Happy to revisit at a later date and look into encryption at
rest. This should be on-par with using Kubernetes in its
default unencrypted state.

Fixes: #29

Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

```sh
$ echo "do not tell" | faas-cli secret create alex -g 127.0.0.1:8081

$ faas-cli deploy --image functions/alpine:latest --fprocess="cat /var/openfaas/secrets/alex" --name cat-secret -g 127.0.0.1:8081 --secret alex

$ curl -d "" http://127.0.0.1:8081/function/cat-secret

$ faas secret ls -g 127.0.0.1:8081
NAME
alex

$ faas-cli deploy --image functions/alpine:latest --fprocess="cat /var/openfaas/secrets/alex" --name bad-secret -g 127.0.0.1:8081 --secret bad-secret

Unexpected status: 400, message: unable to find secret: bad-secret
unable to start task: bad-secret, error: OCI runtime create failed: container_linux.go:345: starting container process caused "process
_linux.go:430: container init caused \"rootfs_linux.go:58: mounting \\\"/home/alex/go/src/github.com/alexellis/faasd/secrets/bad-secre
t\\\" to rootfs \\\"/run/containerd/io.containerd.runtime.v2.task/openfaas-fn/bad-secret/rootfs\\\" at \\\"/var/openfaas/secrets/bad-s
ecret\\\" caused \\\"stat /home/alex/go/src/github.com/alexellis/faasd/secrets/bad-secret: no such file or directory\\\"\"": unknown

Function 'bad-secret' failed to deploy with status code: 400
```
