### PR TITLE
Fix/provider name

### DIFF
--- a/cmd/provider.go
+++ b/cmd/provider.go
@@ -32,7 +32,7 @@ func runProvider(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	log.Printf("faas-containerd starting..\tService Timeout: %s\n", config.WriteTimeout.String())
+	log.Printf("faasd-provider starting..\tService Timeout: %s\n", config.WriteTimeout.String())
 
 	wd, err := os.Getwd()
 	if err != nil {

--- a/cmd/provider.go
+++ b/cmd/provider.go
@@ -21,7 +21,7 @@ import (
 
 var providerCmd = &cobra.Command{
 	Use:   "provider",
-	Short: "Run the faasd faas-provider",
+	Short: "Run the faasd-provider",
 	RunE:  runProvider,
 }
 

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -217,7 +217,7 @@ func makeServiceDefinitions(archSuffix string) []pkg.Service {
 			Name: "gateway",
 			Env: []string{
 				"basic_auth=true",
-				"functions_provider_url=http://faas-containerd:8081/",
+				"functions_provider_url=http://faasd-provider:8081/",
 				"direct_functions=false",
 				"read_timeout=60s",
 				"write_timeout=60s",

--- a/hack/faasd.service
+++ b/hack/faasd.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=faasd
-After=faas-containerd.service
+After=faasd-provider.service
 
 [Service]
 MemoryLimit=500M

--- a/pkg/supervisor.go
+++ b/pkg/supervisor.go
@@ -82,7 +82,7 @@ func (s *Supervisor) Start(svcs []Service) error {
 	}
 	hosts := fmt.Sprintf(`
 127.0.0.1	localhost
-%s	faas-containerd`, gw)
+%s	faasd-provider`, gw)
 
 	writeHostsErr := ioutil.WriteFile(path.Join(wd, "hosts"),
 		[]byte(hosts), workingDirectoryPermission)

--- a/pkg/supervisor.go
+++ b/pkg/supervisor.go
@@ -49,12 +49,12 @@ type Supervisor struct {
 func NewSupervisor(sock string) (*Supervisor, error) {
 	client, err := containerd.New(sock)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
 	cni, err := cninetwork.InitNetwork()
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
 	return &Supervisor{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fix/provider name

## Motivation and Context

Not sure how this got reverted / affected, but was wrong. The
name "faas-containerd" is gone and not in use.

Errors should be returned and handled in the caller, removed some 
invalid panic statements.

